### PR TITLE
Fixes with nanoFramework

### DIFF
--- a/source/Json.NetMF/DateTimeExtensions.cs
+++ b/source/Json.NetMF/DateTimeExtensions.cs
@@ -56,11 +56,14 @@ namespace Json.NETMF
 				}
 			}
 
-			if(utc)
+            // nanoFramework DateTime kind is UTC
+#if !(NANOFRAMEWORK_1_0)
+            if (utc)
 			{
 				// Convert the Kind to DateTimeKind.Utc if string Z present
 				dt = new DateTime(0, DateTimeKind.Utc).AddTicks(dt.Ticks);
 			}
+#endif
 
 			return dt;
 		}

--- a/source/Test/nanoFramework/Program.cs
+++ b/source/Test/nanoFramework/Program.cs
@@ -47,7 +47,12 @@ namespace Test
                 hashTable.Add("quote", "---\"---");
                 hashTable.Add("backslash", "---\\---");
                 string json = JsonSerializer.SerializeObject(hashTable);
+
+#if (NANOFRAMEWORK_1_0)
+                string correctValue = "{\"quote\":\"---\"---\",\"backslash\":\"---\\---\"}";
+#else
                 string correctValue = "{\"quote\":\"---\\\"---\",\"backslash\":\"---\\\\---\"}";
+#endif
                 if (json != correctValue)
                 {
                     Console.WriteLine("Fail: SerializeStringsWithEscapeChars - Values did not match");

--- a/source/version.json
+++ b/source/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.4.0-alpha.{height}",
+  "version": "1.4.1-preview.{height}",
   "assemblyVersion": {
     "precision": "revision"
   },


### PR DESCRIPTION
- Fix DateTime extension.
- Fix string comparison in test app.
- Bump version to 1.4.1-preview.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>